### PR TITLE
Revert "chore(deps): update helm chart kube-prometheus-stack to v15.1.3"

### DIFF
--- a/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      version: 15.1.3
+      version: 15.1.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts


### PR DESCRIPTION
Reverts billimek/k8s-gitops#872

Still getting errors with upgrade:

```
cannot patch "kube-prometheus-stack-alertmanager" with kind Ingress: Ingress.extensions "kube-prometheus-stack-alertmanager" is invalid: spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified
```

```
cannot patch "kube-prometheus-stack-prometheus" with kind Ingress: Ingress.extensions "kube-prometheus-stack-prometheus" is invalid: spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified
```