### PR TITLE
Revert "feat(charts): update helm chart velero to 2.25.0"

### DIFF
--- a/velero/velero/velero.yaml
+++ b/velero/velero/velero.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       # renovate: registryUrl=https://vmware-tanzu.github.io/helm-charts
       chart: velero
-      version: 2.25.0
+      version: 2.24.0
       sourceRef:
         kind: HelmRepository
         name: vmware-tanzu-charts


### PR DESCRIPTION
There may be problems with the new chart version 2.25.0:

```
reconciliation failed: Helm upgrade failed: YAML parse error on velero/templates/restic-daemonset.yaml: error converting YAML to JSON: yaml: line 32: mapping values are not allowed in this context
```