### PR TITLE
Revert "fix(images): update docker image zwavejs/zwavejs2mqtt to 6.5.2"

### DIFF
--- a/default/zwavejs2mqtt/zwave2mqtt.yaml
+++ b/default/zwavejs2mqtt/zwave2mqtt.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: zwavejs/zwavejs2mqtt
-      tag: 6.5.2
+      tag: 6.5.1
     env:
       TZ: "America/New_York"
     securityContext:


### PR DESCRIPTION
Reverts billimek/k8s-gitops#2066

This was failing with,

```
Error: EMFILE: too many open files, watch '/usr/src/app/store'
    at FSWatcher.<computed> (node:internal/fs/watchers:244:19)
    at Object.watch (node:fs:2237:34)
    at watch (/usr/src/app/server/lib/Gateway.js:72:35)
    at Object.<anonymous> (/usr/src/app/server/lib/Gateway.js:123:1)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18)
failed to create fsnotify watcher: too many open files
```