### PR TITLE
Revert "fix(charts): update helm chart emqx to 4.4.4"

### DIFF
--- a/default/emqx/emqx.yaml
+++ b/default/emqx/emqx.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://repos.emqx.io/charts
       chart: emqx
-      version: 4.4.4
+      version: 4.4.3
       sourceRef:
         kind: HelmRepository
         name: emqx-charts


### PR DESCRIPTION
Reverts billimek/k8s-gitops#2404

Due to [this bug](https://github.com/emqx/emqx/issues/8185)