### PR TITLE
Revert "fix(charts): update helm chart ingress-nginx to 4.4.3"

### DIFF
--- a/kube-system/nginx/nginx.yaml
+++ b/kube-system/nginx/nginx.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes.github.io/ingress-nginx
       chart: ingress-nginx
-      version: 4.4.3
+      version: 4.4.2
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx-charts


### PR DESCRIPTION
Reverts billimek/k8s-gitops#2892

That version is no bueno.  See [this issue](https://github.com/kubernetes/ingress-nginx/issues/9569).