### PR TITLE
Revert "fix(charts): update helm chart influxdb to 4.12.2"

### DIFF
--- a/monitoring/influxdb/influxdb.yaml
+++ b/monitoring/influxdb/influxdb.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://helm.influxdata.com/
       chart: influxdb
-      version: 4.12.2
+      version: 4.12.1
       sourceRef:
         kind: HelmRepository
         name: influxdata-charts


### PR DESCRIPTION
Reverts billimek/k8s-gitops#3174

I should have trusted the helm testing action when it complained there was an issue with this release.