### PR TITLE
Revert "feat(container): update flux group (minor)"

### DIFF
--- a/flux-system/gotk-components.yaml
+++ b/flux-system/gotk-components.yaml
@@ -4570,7 +4570,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/source-controller:v1.4.1
+        image: ghcr.io/fluxcd/source-controller:v1.3.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -10301,7 +10301,7 @@ spec:
             resourceFieldRef:
               containerName: manager
               resource: limits.memory
-        image: ghcr.io/fluxcd/helm-controller:v1.1.0
+        image: ghcr.io/fluxcd/helm-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Reverts billimek/k8s-gitops#4049

```
 {"level":"error","ts":"2024-09-27T13:23:38.275Z","logger":"setup","msg":"unable to start manager","error":"failed to determine if *v1.Bucket is namespaced: failed │
│  to get restmapping: no matches for kind \"Bucket\" in version \"source.toolkit.fluxcd.io/v1\""}
```

This pull request includes downgrades to the versions of two container images in the `flux-system/gotk-components.yaml` file.

Container image version downgrades:

* [`flux-system/gotk-components.yaml`](diffhunk://#diff-f9d5127c6ebb504e9413d91c6ebef1948582fee682e3b7f2bbdce9a669495af8L4573-R4573): Changed the `source-controller` image from `v1.4.1` to `v1.3.0`.
* [`flux-system/gotk-components.yaml`](diffhunk://#diff-f9d5127c6ebb504e9413d91c6ebef1948582fee682e3b7f2bbdce9a669495af8L10304-R10304): Changed the `helm-controller` image from `v1.1.0` to `v1.0.1`.