### PR TITLE
Revert "feat(container): update external secrets operator group"

### DIFF
--- a/kubernetes/kube-system/external-secrets/chart/external-secrets.yaml
+++ b/kubernetes/kube-system/external-secrets/chart/external-secrets.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 0.16.0
+      version: 0.15.1
       sourceRef:
         kind: HelmRepository
         name: external-secrets

--- a/setup/crds/kustomization.yaml
+++ b/setup/crds/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   # │ external-secrets     │
   # └──────────────────────┘
   # renovate: datasource=github-releases depName=external-secrets/external-secrets
-  - https://github.com/external-secrets/external-secrets/raw/v0.16.0/deploy/crds/bundle.yaml
+  - https://github.com/external-secrets/external-secrets/raw/v0.15.1/deploy/crds/bundle.yaml
 
   # ┌──────────────────────┐
   # │ external-snapshotter │


### PR DESCRIPTION
Reverts billimek/k8s-gitops#4381

```
ClusterSecretStore/kube-system/onepassword-connect dry-run failed: conversion webhook for external-secrets.io/v1beta1, Kind=ClusterSecretStore failed: no kind "ClusterSecretStore" is registered for version "external-secrets.io/v1" in scheme "pkg/runtime/scheme.go:100"
```

... Going to better understand what additional changes are necessary to properly support this.