### PR TITLE
Revert "fix(container): update image ghcr.io/home-assistant/home-assistant ( 2025.10.1 → 2025.10.2 )"

### DIFF
--- a/kubernetes/default/home-assistant/home-assistant.yaml
+++ b/kubernetes/default/home-assistant/home-assistant.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-assistant/home-assistant
-              tag: 2025.10.2
+              tag: 2025.10.1
             env:
               TZ: "America/New_York"
               PYTHONPATH: "/config/deps"


### PR DESCRIPTION
Reverts billimek/k8s-gitops#4867

```
ImportError: cannot import name 'evaluate_forward_ref' from 'typing_extensions' (/config/deps/typing_extensions.py)
```