### PR TITLE
fix(talos): enable search domains for node name resolution

### DIFF
--- a/setup/talos/patches/global/machine-network.yaml
+++ b/setup/talos/patches/global/machine-network.yaml
@@ -1,6 +1,3 @@
 machine:
   network:
     disableSearchDomain: false
-    searches:
-      - cluster.local
-      - home


### PR DESCRIPTION
Allow pods to resolve short node names (k8s-0) by adding explicit search domains.  Kubernetes services resolve via cluster.local first, with . home as fallback for homelab infrastructure.