### PR TITLE
Revert "fix(container): update image grafana ( 10.3.0 → 10.3.1 )"

### DIFF
--- a/kubernetes/monitoring/grafana/grafana.yaml
+++ b/kubernetes/monitoring/grafana/grafana.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: grafana
-      version: 10.3.1
+      version: 10.3.0
       sourceRef:
         kind: HelmRepository
         name: grafana-charts


### PR DESCRIPTION
12.3.0 is a buggy release