### PR TITLE
Revert "feat(helm): update chart tailscale-operator ( 1.90.9 → 1.92.3 )"

### DIFF
--- a/kubernetes/kube-system/tailscale/tailscale-operator.yaml
+++ b/kubernetes/kube-system/tailscale/tailscale-operator.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: tailscale-operator
-      version: 1.92.3
+      version: 1.90.9
       interval: 30m
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Reverts billimek/k8s-gitops#5046

Rolling back due to crashlooping,

```
{"level":"fatal","ts":"2025-12-17T19:55:46Z","logger":"startup","msg":"CLIENT_ID_FILE and CLIENT_SECRET_FILE must be set","stacktrace":"main.initTSNet\n\ttailscale.com/cmd/k8s-operator/operator.go:182\nmain.main\n\ttailscale.com/cmd/k8s-operator/operator.go:126\nruntime.main\n\truntime/proc.go:285"}
```