### PR TITLE
feat: add qui modern web UI for qBittorrent

### DIFF
--- a/kubernetes/default/qui/externalsecret.yaml
+++ b/kubernetes/default/qui/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qui
+  namespace: default
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: qui-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: QUI__SESSION_SECRET
+      remoteRef:
+        key: qui
+        property: session_secret

--- a/kubernetes/default/qui/qui.yaml
+++ b/kubernetes/default/qui/qui.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: qui
+  namespace: default
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  values:
+    controllers:
+      qui:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/autobrr/qui
+              tag: main@sha256:c32ed99bb66b96776e2059881ca55122599b923a36bfc157ed6607ea5c804562
+            env:
+              QUI__HOST: 0.0.0.0
+              QUI__PORT: &port 7476
+              QUI__LOG_LEVEL: INFO
+              TZ: America/New_York
+            envFrom:
+              - secretRef:
+                  name: qui-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: qui
+        ports:
+          http:
+            port: *port
+
+    route:
+      main:
+        enabled: true
+        annotations:
+          external-dns.alpha.kubernetes.io/internal: "true"
+          external-dns.alpha.kubernetes.io/target: "10.0.6.151"
+        parentRefs:
+          - name: internal
+            namespace: kube-system
+        hostnames:
+          - qui.eviljungle.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: qui
+                port: 7476
+
+    persistence:
+      config:
+        suffix: config
+        storageClass: "ceph-block"
+        accessMode: ReadWriteOnce
+        size: "1Gi"
+      media:
+        type: nfs
+        server: nas.home
+        path: /mnt/tank/media
+        globalMounts:
+          - path: /media/downloads/torrents
+            subPath: downloads/torrents
+      tmp:
+        type: emptyDir

--- a/kubernetes/default/qui/volsync.yaml
+++ b/kubernetes/default/qui/volsync.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qui-restic
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: qui-restic-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: '{{ .REPOSITORY_TEMPLATE }}/qui'
+        RESTIC_PASSWORD: '{{ .RESTIC_PASSWORD }}'
+        AWS_ACCESS_KEY_ID: '{{ .VOLSYNC_ACCESS_KEY }}'
+        AWS_SECRET_ACCESS_KEY: '{{ .VOLSYNC_SECRET_KEY }}'
+  dataFrom:
+    - extract:
+        key: garage
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: qui
+  namespace: default
+spec:
+  sourcePVC: qui-config
+  trigger:
+    schedule: "0 6 * * *"
+  restic:
+    copyMethod: Snapshot
+    pruneIntervalDays: 10
+    repository: qui-restic-secret
+    cacheCapacity: 2Gi
+    volumeSnapshotClassName: csi-ceph-blockpool
+    storageClassName: ceph-block
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+    retain:
+      daily: 10
+      within: 3d


### PR DESCRIPTION
## Summary

Implements #5084 - Adds qui, a modern alternative web interface for qBittorrent with multi-instance support.

## What is qui?

qui is a fast, modern web UI for qBittorrent written in Go/React that provides:
- Multi-instance qBittorrent management
- Cross-seed detection across trackers
- Tracker health monitoring
- Automated torrent management rules
- Backup/restore capabilities
- Clean, responsive interface with theming

## Configuration Details

- **Hostname**: `qui.eviljungle.com` (internal-only access)
- **Port**: 7476 (qui default)
- **Storage**: 1Gi ceph-block PVC for SQLite database
- **NFS Mount**: Torrents directory for cross-seed detection
- **Backups**: Daily at 6 AM via VolSync to garage
- **Authentication**: Uses qBittorrent's subnet bypass (10.0.0.0/8)
- **Image**: `ghcr.io/autobrr/qui:main@sha256:c32ed99bb66b96776e2059881ca55122599b923a36bfc157ed6607ea5c804562`

## Files Added

- `kubernetes/default/qui/qui.yaml` - HelmRelease configuration
- `kubernetes/default/qui/externalsecret.yaml` - Session secret from 1Password
- `kubernetes/default/qui/volsync.yaml` - Backup configuration

## Pre-Merge Requirements

**⚠️ IMPORTANT: Create 1Password secret before merging**

```bash
# 1. Generate session secret
openssl rand -hex 32

# 2. In 1Password:
#    - Create item named: qui
#    - Add field: session_secret
#    - Paste the generated hex string
```

## Post-Deployment Steps

1. Wait for Flux to reconcile the HelmRelease
2. Access https://qui.eviljungle.com
3. Create qui admin account (first-time setup)
4. Add qBittorrent instance:
   - Host: `http://qbittorrent.default.svc.cluster.local`
   - Port: `80`
   - Username/Password: Leave blank (auth bypass configured)
5. Verify connection and torrent list appears

## Testing Checklist

- [x] 1Password secret created
- [ ] HelmRelease deploys successfully
- [ ] Pod starts and reaches Running state
- [ ] PVC `qui-config` created
- [ ] HTTPRoute accessible at https://qui.eviljungle.com
- [ ] Admin account creation works
- [ ] qBittorrent connection succeeds
- [ ] Torrent list displays correctly
- [ ] VolSync backup job runs successfully

## Reference Implementation

Based on https://github.com/buroa/k8s-gitops/tree/main/kubernetes/apps/media/qui/app