### PR TITLE
feat(frigate): migrate from Coral USB to OpenVINO detector

### DIFF
--- a/kubernetes/default/frigate/frigate-configmap.yml
+++ b/kubernetes/default/frigate/frigate-configmap.yml
@@ -23,9 +23,17 @@ data:
       path: /config/frigate.db
 
     detectors:
-      coral:
-        type: edgetpu
-        device: usb
+      ov:
+        type: openvino
+        device: GPU
+
+    model:
+      width: 300
+      height: 300
+      input_tensor: nhwc
+      input_pixel_format: bgr
+      path: /openvino-model/ssdlite_mobilenet_v2.xml
+      labelmap_path: /openvino-model/coco_91cl_bkgr.txt
 
     # birdseye:
     #   enabled: true

--- a/kubernetes/default/frigate/frigate.yaml
+++ b/kubernetes/default/frigate/frigate.yaml
@@ -19,13 +19,32 @@ spec:
           resourceClaimTemplateName: frigate
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: google.feature.node.kubernetes.io/coral
+          # Soft preferences - scheduler tries these in order but allows fallback
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # Tier 1: Intel N100 (Gen 12 Xe) - Best for OpenVINO inference
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: intel.feature.node.kubernetes.io/gpu-gen
                     operator: In
                     values:
-                      - "true"
+                      - "12"
+            # Tier 2: Coffee Lake UHD 630 - Good OpenVINO performance
+            - weight: 70
+              preference:
+                matchExpressions:
+                  - key: intel.feature.node.kubernetes.io/gpu-family
+                    operator: In
+                    values:
+                      - "coffeelake"
+            # Tier 3: Kaby Lake HD 630 - Acceptable OpenVINO performance
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: intel.feature.node.kubernetes.io/gpu-family
+                    operator: In
+                    values:
+                      - "kabylake"
     controllers:
       main:
         containers:
@@ -67,7 +86,6 @@ spec:
                 cpu: 1500m
               limits:
                 memory: 4000Mi
-                generic-device-plugin/coral: 1
 
     service:
       main:


### PR DESCRIPTION
## Overview

Migrates Frigate's object detection from Google Coral USB TPU to OpenVINO running on Intel iGPU. This is **Phase 1** of the migration plan - validating OpenVINO works with the same model architecture before upgrading to more advanced models.

## Changes

### Detector Configuration (`frigate-configmap.yml`)
- Switch from `edgetpu` detector to `openvino` detector
- Configure OpenVINO to use Intel GPU
- Use built-in SSDLite MobileNetV2 model (same architecture as Coral)
- Keep VAAPI video decoding enabled

### Resource Allocation (`frigate.yaml`)
- Remove Coral USB device requirement (`generic-device-plugin/coral: 1`)
- Remove hard Coral node affinity requirement
- Add **weighted Intel GPU tier preferences** (similar to Plex):
  - **Tier 1 (weight 100)**: Intel N100 Gen 12 Xe - Best OpenVINO performance (~15ms inference)
  - **Tier 2 (weight 70)**: Coffee Lake UHD 630 - Good performance
  - **Tier 3 (weight 50)**: Kaby Lake HD 630 - Acceptable performance

## Expected Outcomes

| Metric | Current (Coral) | Expected (OpenVINO) |
|--------|----------------|---------------------|
| **Inference Time** | ~10ms | ~15ms |
| **Detection Accuracy** | Baseline | Same (identical model) |
| **Model** | TFLite MobileNetV2 | ONNX MobileNetV2 |
| **GPU Usage** | None (dedicated TPU) | Shared with VAAPI decode |

## Testing Plan

After merge, monitor for 24-48 hours:

1. **Verify deployment**:
   ```bash
   kubectl get pod -n default -l app.kubernetes.io/name=frigate -o wide
   kubectl logs -n default -l app.kubernetes.io/name=frigate | grep -i openvino
   ```

2. **Check Frigate UI**:
   - System → Configuration → Detectors (should show `ov` with `openvino` type)
   - System → Stats (inference times should be 10-20ms)

3. **Validate detection quality**:
   - Compare event frequency to baseline
   - Check for missed detections or false positives

## Rollback Plan

If issues occur, revert this PR to restore Coral operation.

## Next Steps (Phase 2)

After validating Phase 1, we can proceed with Phase 2:
- Download YOLOv9-t ONNX model (~6MB)
- Update config to use YOLOv9 for ~70% better detection accuracy
- Expected inference time: ~16-20ms

## References

- Issue: #5095
- [Frigate Object Detectors Docs](https://docs.frigate.video/configuration/object_detectors)
- [Frigate Hardware Recommendations](https://docs.frigate.video/frigate/hardware)