### PR TITLE
feat(frigate): upgrade to YOLOv9-t model for improved detection accuracy

### DIFF
--- a/kubernetes/default/frigate/frigate-configmap.yml
+++ b/kubernetes/default/frigate/frigate-configmap.yml
@@ -28,12 +28,13 @@ data:
         device: GPU
 
     model:
-      width: 300
-      height: 300
-      input_tensor: nhwc
-      input_pixel_format: bgr
-      path: /openvino-model/ssdlite_mobilenet_v2.xml
-      labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+      model_type: yolo-generic
+      width: 320
+      height: 320
+      input_tensor: nchw
+      input_dtype: float
+      path: /config/model_cache/yolov9-t-320.onnx
+      labelmap_path: /labelmap/coco-80.txt
 
     # birdseye:
     #   enabled: true


### PR DESCRIPTION
## Summary
- Phase 2 of Frigate OpenVINO migration (Phase 1 merged in #5096)
- Upgrades detection model from MobileNetV2 to YOLOv9-t for ~70% better accuracy
- Model pre-uploaded to Frigate PVC at `/config/model_cache/yolov9-t-320.onnx`

## Changes
- Updated `frigate-configmap.yml` detector model configuration:
  - Changed from MobileNetV2 (22% mAP) to YOLOv9-t (38% mAP)
  - Model type: `yolo-generic` with 320x320 input size
  - Input format: NCHW float tensor (YOLO standard)
  - Using COCO-80 labelmap (standard 80 object classes)

## Performance Expectations
| Metric | Phase 1 (Current) | Phase 2 (After) |
|--------|-------------------|-----------------|
| Model | MobileNetV2 | YOLOv9-t |
| Inference Time | ~15ms | ~16-20ms |
| Accuracy (mAP) | ~22% | ~38% |
| Detection Quality | Baseline | +70% improvement |

## Testing
- Model downloaded and exported to ONNX format (7.8MB)
- Pre-uploaded to Frigate PVC to avoid runtime download
- Expected inference time: 16-20ms on N100 iGPU
- Max detection load: ~30 FPS (well within N100 capacity of 50-60 FPS)

## Verification Steps
After merge, check:
1. Frigate UI → System → Stats for inference times (should be 16-20ms)
2. Frigate logs: `kubectl logs -n default -l app.kubernetes.io/name=frigate | grep -i yolo`
3. Monitor detection quality over 24-48 hours (fewer missed detections, better bounding boxes)

## Rollback Plan
If issues arise, revert this PR to return to MobileNetV2 configuration.

Relates to #5095