### PR TITLE
feat(mosquitto): add Mosquitto MQTT broker deployment

### DIFF
--- a/kubernetes/default/mosquitto/externalsecret.yaml
+++ b/kubernetes/default/mosquitto/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mosquitto
+  namespace: default
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mosquitto-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Mosquitto password file format: username:password
+        # Note: Plaintext passwords will generate a warning but work
+        # For production, consider hashing with mosquitto_passwd
+        passwd: |
+          {{ .user_mqtt_username }}:{{ .user_mqtt_password }}
+  dataFrom:
+    - extract:
+        key: emqx

--- a/kubernetes/default/mosquitto/mosquitto.yaml
+++ b/kubernetes/default/mosquitto/mosquitto.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v4.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mosquitto
+  namespace: default
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      mosquitto:
+        containers:
+          app:
+            image:
+              repository: public.ecr.aws/docker/library/eclipse-mosquitto
+              tag: 2.0.22@sha256:077fe4ff4c49df1e860c98335c77dda08360629e0e2a718147027e4db3eace9d
+            env:
+              TZ: America/New_York
+            probes:
+              liveness:
+                enabled: true
+                type: TCP
+                spec:
+                  port: 1883
+              readiness:
+                enabled: true
+                type: TCP
+                spec:
+                  port: 1883
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 100Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      app:
+        controller: mosquitto
+        type: LoadBalancer
+        loadBalancerIP: 10.0.6.54
+        ports:
+          mqtt:
+            port: 1883
+            protocol: TCP
+          websocket:
+            port: 9001
+            protocol: TCP
+
+    configMaps:
+      config:
+        data:
+          mosquitto.conf: |
+            # Authentication: allow both anonymous and authenticated clients
+            allow_anonymous true
+            password_file /mosquitto/config/passwd
+            
+            # Persistence
+            persistence true
+            persistence_location /data
+            autosave_interval 60
+            
+            # Performance & Logging
+            connection_messages false
+            per_listener_settings false
+            
+            # Standard MQTT listener
+            listener 1883 0.0.0.0
+            protocol mqtt
+            
+            # WebSocket listener (for web clients)
+            listener 9001 0.0.0.0
+            protocol websockets
+
+    persistence:
+      data:
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /data
+      config-file:
+        type: configMap
+        name: mosquitto-config
+        globalMounts:
+          - path: /mosquitto/config/mosquitto.conf
+            subPath: mosquitto.conf
+            readOnly: true
+      passwd-file:
+        type: secret
+        name: mosquitto-secret
+        globalMounts:
+          - path: /mosquitto/config/passwd
+            subPath: passwd
+            readOnly: true


### PR DESCRIPTION
## Summary

This PR adds Mosquitto MQTT broker as a parallel deployment alongside the existing EMQX broker, enabling a gradual migration path from EMQX to the more lightweight Mosquitto implementation.

## Changes

### New Resources
- **HelmRelease**: Mosquitto 2.0.22 using bjw-s app-template v4
- **ExternalSecret**: Password authentication using existing EMQX 1Password vault
- **LoadBalancer Service**: Dedicated IP `10.0.6.54`

### Configuration Details

**Network:**
- **LoadBalancer IP**: `10.0.6.54` (verified available)
- **Port 1883**: Standard MQTT (TCP)
- **Port 9001**: MQTT over WebSocket (for browser/web clients)

**Authentication:**
- Hybrid mode: anonymous access + password file
- Reuses existing EMQX credentials (`mqtt/mqtt`) from 1Password vault `emqx`
- Note: Plaintext passwords in password file (will log warning but functional)

**Storage:**
- 1Gi Ceph block storage for persistence
- Enables retained messages and QoS 1/2 message queuing
- No VolSync backups (MQTT data is ephemeral)

**Security:**
- Runs as UID/GID `1001/1001` (repo standard)
- Non-root user with read-only root filesystem
- Dropped capabilities, runtime default seccomp profile

**Resource Limits:**
- CPU request: 10m
- Memory limit: 100Mi

## Migration Strategy

This deployment does **NOT** change any existing services:
- ✅ EMQX remains active at `10.0.6.50`
- ✅ All current clients (TeslaMate, etc.) continue using EMQX
- ✅ No DNS or routing changes

### Testing Plan

1. **Verify deployment**:
   ```bash
   kubectl get pods -n default -l app.kubernetes.io/name=mosquitto
   kubectl get svc -n default mosquitto
   ```

2. **Test connectivity**:
   ```bash
   # Anonymous access
   mosquitto_pub -h 10.0.6.54 -t test/anon -m "test"
   mosquitto_sub -h 10.0.6.54 -t test/anon
   
   # Authenticated access
   mosquitto_pub -h 10.0.6.54 -u mqtt -P mqtt -t test/auth -m "test"
   mosquitto_sub -h 10.0.6.54 -u mqtt -P mqtt -t test/auth
   ```

3. **Test persistence**:
   ```bash
   mosquitto_pub -h 10.0.6.54 -t test/retained -m "persistent" -r
   # Restart pod, then subscribe - should receive message immediately
   ```

### Future Migration Steps (Not in This PR)

When ready to migrate:
1. Update one client at a time to use `10.0.6.54`
2. Test each client for 24-48 hours
3. Once all clients migrated, scale down EMQX
4. Optionally repurpose `10.0.6.50` IP for Mosquitto
5. Remove EMQX resources

## Related Issues

- Addresses #4496 (migrate away from EMQX)

## Checklist

- [x] Follows repository patterns and conventions
- [x] Uses standard UID/GID (1001/1001)
- [x] Includes proper YAML schema validation comments
- [x] Security context properly configured
- [x] Resources limits defined
- [x] ExternalSecret properly configured
- [x] No impact to existing services
- [x] LoadBalancer IP verified available

## Notes

- **Plaintext Password Warning**: Mosquitto will log a warning about plaintext passwords. This is cosmetic and non-blocking. For production hardening, an init container with `mosquitto_passwd` can be added later.
- **WebSocket Support**: Port 9001 enables web-based MQTT clients and debugging tools.
- **Co-existence Period**: Both EMQX and Mosquitto will run simultaneously until migration is complete.