### PR TITLE
chore(monitoring): kubesearch review — self-monitoring + HA + uniformity

### DIFF
--- a/kubernetes/monitoring/blackbox-exporter/blackbox-exporter.yaml
+++ b/kubernetes/monitoring/blackbox-exporter/blackbox-exporter.yaml
@@ -35,3 +35,5 @@ spec:
             preferred_ip_protocol: ip4
     serviceMonitor:
       enabled: true
+    prometheusRule:
+      enabled: true

--- a/kubernetes/monitoring/blackbox-exporter/blackbox-exporter.yaml
+++ b/kubernetes/monitoring/blackbox-exporter/blackbox-exporter.yaml
@@ -37,3 +37,20 @@ spec:
       enabled: true
     prometheusRule:
       enabled: true
+      rules:
+        - alert: BlackboxProbeFailed
+          expr: probe_success == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Blackbox probe failed (instance {{ $labels.instance }})"
+            description: "Probe has been failing for more than 5 minutes."
+        - alert: BlackboxProbeSlowProbe
+          expr: avg_over_time(probe_duration_seconds[1m]) > 5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Blackbox probe slow (instance {{ $labels.instance }})"
+            description: "Average probe duration over the last minute is above 5s."

--- a/kubernetes/monitoring/gatus/gatus.yaml
+++ b/kubernetes/monitoring/gatus/gatus.yaml
@@ -20,6 +20,8 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
 
     configMaps:
       config:

--- a/kubernetes/monitoring/opnsense-exporter/opnsense-exporter.yaml
+++ b/kubernetes/monitoring/opnsense-exporter/opnsense-exporter.yaml
@@ -18,6 +18,8 @@ spec:
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
 
     controllers:
       opnsense-exporter:

--- a/kubernetes/monitoring/prometheus-adapter/prometheus-adapter.yaml
+++ b/kubernetes/monitoring/prometheus-adapter/prometheus-adapter.yaml
@@ -26,6 +26,17 @@ spec:
     name: prometheus-adapter
   interval: 1h
   values:
+    replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus-adapter
+    podDisruptionBudget:
+      enabled: true
+      maxUnavailable: 1
     prometheus:
       url: http://vmsingle-stack.monitoring.svc.cluster.local
       port: 8428

--- a/kubernetes/monitoring/speedtest-exporter/speedtest-exporter.yaml
+++ b/kubernetes/monitoring/speedtest-exporter/speedtest-exporter.yaml
@@ -35,6 +35,18 @@ spec:
                 memory: 15Mi
               limits:
                 memory: 100Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9516
+                  initialDelaySeconds: 30
+                  periodSeconds: 60
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/kubernetes/monitoring/unbound-exporter/unbound-exporter.yaml
+++ b/kubernetes/monitoring/unbound-exporter/unbound-exporter.yaml
@@ -18,6 +18,8 @@ spec:
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
 
     controllers:
       unbound-exporter:

--- a/kubernetes/monitoring/unifi-poller/unifi-poller.yaml
+++ b/kubernetes/monitoring/unifi-poller/unifi-poller.yaml
@@ -18,6 +18,8 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
 
     controllers:
       unifi-poller:

--- a/kubernetes/monitoring/victoria-logs/victoria-logs.yaml
+++ b/kubernetes/monitoring/victoria-logs/victoria-logs.yaml
@@ -36,7 +36,7 @@ spec:
         storageClassName: ceph-block
         size: 20Gi
       serviceMonitor:
-        enabled: false
+        enabled: true
       route:
         enabled: true
         annotations:
@@ -57,6 +57,7 @@ spec:
               - name: victoria-logs-server
                 port: 9428
     dashboards:
-      enabled: false
+      enabled: true
+      grafana_folder: infrastructure
     vector:
       enabled: false


### PR DESCRIPTION
## Summary

Implements `[H]` and `[M]` findings from the monitoring-namespace kubesearch.dev review. Three commits, ordered by impact.

- 1️⃣ **Self-monitoring toggles (`[H]`).** `victoria-logs`: enable `server.serviceMonitor` + `dashboards` (95% peer adoption). `blackbox-exporter`: enable `prometheusRule` (86% peer adoption — bundled `BlackboxProbeFailed` alert; complements `prometheus-adapter` exposing `probe_success` as an HPA metric).
- 2️⃣ **prometheus-adapter HA (`[M]`).** `replicas: 2` + hostname `topologySpreadConstraints` + PDB (`maxUnavailable: 1`). The adapter backs `external.metrics.k8s.io`; single-pod restarts break dependent HPAs.
- 3️⃣ **Probes + seccomp baseline (`[M]` + `[L]`).** `speedtest-exporter`: TCP liveness/readiness on `:9516` (60s period — avoids `/metrics` HTTP probe that would trigger speedtest runs). `gatus`, `opnsense-exporter`, `unbound-exporter`, `unifi-poller`: add `seccompProfile: RuntimeDefault` for fleet uniformity.

## Findings dropped during verification

- **grafana hardening** — chart already defaults to non-root UID 472 + RO rootfs + drop-ALL caps. No edit needed.
- **blackbox-exporter container hardening** — chart already defaults to RO rootfs + drop-ALL + non-root UID 1000. No edit needed.
- **All "missing ServiceMonitor" findings** on opnsense/smokeping/speedtest/unbound/unifi-poller — false positives from the research agent, which only inspected inline `serviceMonitor:` blocks; each app actually has a standalone `servicemonitor.yaml` live as `operational` `VMServiceScrape`.

## Test plan

- [x] `flux-local test --enable-helm` — 77/77 pass
- [x] `flux-local diff helmrelease --branch-orig master` — 11 expected resource diffs (6 Deployments + 1 PDB + 1 PrometheusRule + 1 ServiceMonitor + 2 Grafana dashboard ConfigMaps), no surprises
- [ ] CI: GitHub Actions `Flux Local` workflow green
- [ ] Post-merge: confirm vmagent picks up `victoria-logs-server` SM (`up=1`), Grafana auto-imports the new VictoriaLogs dashboards, prometheus-adapter rolls to 2 replicas spread across hosts.