### PR TITLE
fix(monitoring): label victoria-logs dashboards for grafana sidecar pickup

### DIFF
--- a/kubernetes/monitoring/grafana/grafana.yaml
+++ b/kubernetes/monitoring/grafana/grafana.yaml
@@ -122,9 +122,9 @@ spec:
         cert-manager:
           url: https://grafana.com/api/dashboards/20842/revisions/3/download
           datasource: Prometheus
-        cloudnative-pg:
-          url: https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/monitoring/grafana-dashboard.json
-          datasource: Prometheus
+        # cloudnative-pg dashboard is now provided by the CNPG operator chart
+        # (monitoring.grafanaDashboard.create=true on the cloudnative-pg HR);
+        # the upstream URL we used here returns 404 since a repo restructure.
         flux-control-plane:
           url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
           datasource: Prometheus
@@ -245,10 +245,12 @@ spec:
           url: https://grafana.com/api/dashboards/23233/revisions/6/download
           datasource:
             - {name: DS_PROMETHEUS, value: Prometheus}
-        # kube-prometheus-stack dashboards
-        kube-prometheus-dashboards:
-          url: https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/grafana-dashboardDefinitions.yaml
-          datasource: Prometheus
+        # kube-prometheus-stack dashboards: removed. The upstream URL is a
+        # YAML manifest containing many dashboards-as-ConfigMaps, not a single
+        # dashboard JSON, so the dashboard provisioner errored on
+        # "invalid character 'a' looking for beginning of value".
+        # The vm-stack chart already ships kube-prometheus-stack-equivalent
+        # dashboards as ConfigMaps (visible as `stack-kubernetes-*`).
 
       teslamate:
         battery-health:

--- a/kubernetes/monitoring/victoria-logs/victoria-logs.yaml
+++ b/kubernetes/monitoring/victoria-logs/victoria-logs.yaml
@@ -58,6 +58,9 @@ spec:
                 port: 9428
     dashboards:
       enabled: true
-      grafana_folder: infrastructure
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana_folder: "infrastructure"
     vector:
       enabled: false


### PR DESCRIPTION
## Summary

Two Grafana dashboard fixes caught during post-merge validation of #5614:

### 1. victoria-logs dashboard ConfigMaps not picked up by sidecar

PR #5614 enabled `dashboards.enabled: true` on the victoria-logs HR, which created two CMs but **without** the `grafana_dashboard=1` label that Grafana's sidecar (LABEL=grafana_dashboard) uses for discovery. The sidecar's `/tmp/dashboards/` mount stayed at 27 dashboards, identical to before. Set `dashboards.labels: { grafana_dashboard: "1" }` and move the folder hint to `dashboards.annotations` (where the chart actually puts it).

### 2. Two pre-existing Grafana dashboard URL errors

After bouncing the Grafana pod, sidecar logs surfaced two URL-provisioner errors that were silently happening for a while:

- **`infrastructure/cloudnative-pg.json` — EOF.** Upstream URL returns 404 (CNPG repo restructured). Now redundant: PR #5611 enabled `monitoring.grafanaDashboard.create` on the CNPG operator chart, which already ships a working dashboard via ConfigMap.
- **`kubernetes/kube-prometheus-dashboards.json` — `invalid character 'a' looking for beginning of value`.** The URL was `grafana-dashboardDefinitions.yaml` (YAML manifest, not JSON). The vm-stack chart already ships kube-prometheus-equivalent dashboards as ConfigMaps (`stack-kubernetes-*`).

## Test plan

- [x] `flux-local test --enable-helm` — 77/77 pass
- [x] `flux-local diff` confirms:
  - Both victoria-logs CMs gain `grafana_dashboard: '1'` label + `grafana_folder: infrastructure` annotation
  - Grafana CM removes the two broken URL entries
- [ ] Post-merge: confirm Grafana sidecar mounts `/tmp/dashboards/infrastructure/{vector-k8s-monitoring,victorialogs-single-node}.json`; sidecar+main logs clean of EOF / invalid-character errors.