### PR TITLE
frigate: raise person detection threshold to 0.75

### DIFF
--- a/kubernetes/default/frigate/frigate-configmap.yaml
+++ b/kubernetes/default/frigate/frigate-configmap.yaml
@@ -61,7 +61,7 @@ data:
         person:
           min_area: 2000
           max_area: 100000
-          threshold: 0.72
+          threshold: 0.75
         dog:
           min_area: 1000
           max_area: 10000
@@ -157,7 +157,7 @@ data:
             person:
               min_area: 1500
               max_area: 100000
-              threshold: 0.72
+              threshold: 0.75
               min_score: 0.58
         live:
           streams:
@@ -224,7 +224,7 @@ data:
             person:
               min_area: 1000
               max_area: 100000
-              threshold: 0.72
+              threshold: 0.75
         live:
           streams:
             main_stream: pool_record
@@ -277,7 +277,7 @@ data:
             person:
               min_area: 1500
               max_area: 100000
-              threshold: 0.72
+              threshold: 0.75
               min_score: 0.58
         live:
           streams:


### PR DESCRIPTION
## Summary

- Increases the person detection threshold from `0.72` → `0.75` across all cameras to reduce false positives (e.g. porch chair being misidentified as a person at 73% confidence)
- Updated global `objects.filters.person.threshold` and per-camera overrides for `porch`, `pool`, and `doorbell`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1wmxFCm1apCe71nkSNeoJ)_