### PR TITLE
fix(monitoring): revert victoria-metrics-k8s-stack to 0.82.0 (operator v0.71.0 /metrics hang)

### DIFF
--- a/kubernetes/monitoring/victoria-metrics/victoria-metrics.yaml
+++ b/kubernetes/monitoring/victoria-metrics/victoria-metrics.yaml
@@ -11,7 +11,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.83.0
+    tag: 0.82.0
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json


### PR DESCRIPTION
## Summary

- Reverts `victoria-metrics-k8s-stack` from `0.83.0` back to `0.82.0` (operator `v0.70.1`)
- The `0.82.0 -> 0.83.0` bump (PR #5779) upgraded the bundled operator from `v0.70.1` to `v0.71.0`, which introduced a regression where the operator's own `/metrics` endpoint on `:8080` hangs on every request (TCP connects, but HTTP headers are never returned)
- This fires three alerts: `TargetDown`, `VmagentFailsToScrapeTargets`, and `TooManyLogs` (vmagent logs a warn every ~20s for each failed scrape)
- The operator is otherwise fully healthy (reconciling, readiness passing); only self-metrics are affected
- Likely cause: v0.71.0's new "status metrics for objects managed by each controller" (issue VictoriaMetrics/operator#2238) - a new per-object collector running on every scrape that is slow enough to blow the timeout; no env var to disable it
- No fixed operator release exists yet (v0.71.0 is the latest tag); reverting to 0.82.0 is the cleanest fix until upstream resolves the hang

## Test plan

- [ ] After merge: `flux reconcile helmrelease vm -n monitoring --with-source`
- [ ] Confirm operator rolls back to v0.70.1: `kubectl get deploy vm-victoria-metrics-operator -n monitoring -o jsonpath='{.spec.template.spec.containers[0].image}'`
- [ ] Confirm target recovers: PromQL `up{job="vm-victoria-metrics-operator"}` returns `1`
- [ ] Three alerts (`TargetDown`, vmagent scrape-failure, too-many-logs) resolve and send `[RESOLVED]` to Discord