### PR TITLE
fix(home-assistant): wipe stale /config/.venv on image version change

### DIFF
--- a/kubernetes/default/home-assistant/home-assistant.yaml
+++ b/kubernetes/default/home-assistant/home-assistant.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2026.7.0@sha256:dba81097ecdee59dda9adaed94e146398a241efaa74a836567c64f5a3f29ca67
+              tag: &hass-image 2026.7.0@sha256:dba81097ecdee59dda9adaed94e146398a241efaa74a836567c64f5a3f29ca67
             env:
               TZ: "America/New_York"
             envFrom:
@@ -84,6 +84,32 @@ spec:
               limits:
                 memory: 1Gi
 
+        initContainers:
+          venv-reset:
+            image:
+              repository: ghcr.io/home-operations/home-assistant
+              tag: *hass-image
+            command: ["/bin/bash", "-c"]
+            args:
+              - |
+                set -eu
+                marker=/config/.hass-image-version
+                current="$(python3 -c 'from homeassistant.const import __version__; print(__version__)')"
+                previous="$(cat "$marker" 2>/dev/null || true)"
+                if [ "$current" != "$previous" ]; then
+                  echo "HA image changed ($previous -> $current); wiping /config/.venv"
+                  rm -rf /config/.venv/* /config/.venv/.[!.]* 2>/dev/null || true
+                  printf '%s' "$current" > "$marker"
+                else
+                  echo "HA image unchanged ($current); keeping /config/.venv cache"
+                fi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+
     persistence:
       config:
         existingClaim: home-assistant-config
@@ -93,6 +119,8 @@ spec:
               - path: /config
             code-server:
               - path: /config
+            venv-reset:
+              - path: /config
       hass-cache:
         storageClass: "ceph-block"
         accessMode: ReadWriteOnce
@@ -100,6 +128,9 @@ spec:
         advancedMounts:
           home-assistant:
             app:
+              - path: /config/.venv
+                subPath: hass-venv
+            venv-reset:
               - path: /config/.venv
                 subPath: hass-venv
       tmpfs:


### PR DESCRIPTION
## Summary
- Fixes the home-assistant pod being unhealthy after #5889 (image 2026.6.4 -> 2026.7.0): the persisted `/config/.venv` shadowed the new image's `aiohttp` with a stale integration-installed copy, causing `TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'` on every websocket request (pod reports Ready but frontend/websocket is broken).
- Root cause: the home-operations home-assistant entrypoint runs `uv venv --system-site-packages --allow-existing /config/.venv` on every boot and reuses the persisted venv; integration-installed deps in that venv take precedence over the image's system packages and never get refreshed on an image bump. Matches home-operations/containers#794.
- Adds a `venv-reset` init container that compares the image's baked-in HA version (`homeassistant.const.__version__`) against a marker file on the config PVC, and wipes `/config/.venv` only when it changed - forcing integration deps to re-resolve against the current image while preserving the cache across normal restarts.

## Test plan
- [x] YAML validated with `yq` (anchor/alias resolves correctly)
- [ ] Merge and `flux reconcile helmrelease home-assistant -n default --with-source`
- [ ] Confirm `venv-reset` init container logs "HA image changed ... wiping /config/.venv" on first rollout
- [ ] Confirm app logs no longer show `decode_text` / websocket traceback
- [ ] Confirm `hass.eviljungle.com` loads and websocket connects
- [ ] Restart again and confirm init container logs "HA image unchanged ... keeping /config/.venv cache"

https://claude.ai/code/session_01CtwdsDPPSzA9yiJNySQqQ6