### PR TITLE
fix(renovate): set minimumReleaseAgeBehaviour to timestamp-optional

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,10 @@
 
   rebaseWhen: 'auto',
   platformAutomerge: true,
+  // GHCR/OCI images (e.g. siderolabs/installer) and github-actions releases often lack a
+  // releaseTimestamp; without this, Renovate's timestamp-required default marks them pending
+  // forever and never opens a PR, even once minimumReleaseAge would otherwise be satisfied.
+  minimumReleaseAgeBehaviour: 'timestamp-optional',
 
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',
   suppressNotifications: [


### PR DESCRIPTION
## Summary
- Renovate's `timestamp-required` default (since 41.150.0) marks releases without a `releaseTimestamp` as pending indefinitely, and `internalChecksFilter: strict` then disables branch/PR creation entirely.
- GHCR/OCI images (`ghcr.io/siderolabs/installer`, victoria-logs charts) and github-actions releases often lack this timestamp, so their `minimumReleaseAge`-gated updates (see `.renovate/overrides.json5` and `.renovate/autoMerge.json5`) never get a PR, even long after the cooldown would otherwise be satisfied.
- Confirmed root cause from today's Renovate debug logs:
  ```
  "Marking 1 release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required"
  "Branch renovate/talos creation is disabled because internalChecksFilter was not met"
  ```
  This is what has been stranding `fix(container): update image ghcr.io/siderolabs/installer ( v1.13.4 -> v1.13.5 )` under "Pending Status Checks" on the [Dependency Dashboard](https://github.com/billimek/k8s-gitops/issues/4368), plus the victoria-logs single/collector and claude-code-action bumps.
- Fix: set `minimumReleaseAgeBehaviour: 'timestamp-optional'` globally, restoring the prior behavior of treating a missing timestamp as passing the age check. Cooldown rules stay in place and still apply normally to deps whose datasource does provide a timestamp.

## Test plan
- [x] `npx -p renovate renovate-config-validator .github/renovate.json5` passes
- [ ] After merge, confirm on the next Renovate run that issue #4368 moves the installer line out of "Pending Status Checks" and a `renovate/talos` PR appears
- [ ] Confirm the resulting PR bumps `ghcr.io/siderolabs/installer` to `v1.13.5` in `kubernetes/system-upgrade/talos-upgrade.yaml` and `setup/talos/talconfig.yaml`

https://claude.ai/code/session_01NhVGgGmRWABDeTT92bRbew