### PR TITLE
fix(renovate): track Talos installer via github-releases for real timestamps

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -132,7 +132,7 @@
       description: "Talos Group",
       groupName: "Talos",
       matchDatasources: ["docker", "github-releases", "helm", "git-tags"],
-      matchPackagePatterns: ["siderolabs/talosctl", "siderolabs/installer"],
+      matchPackagePatterns: ["siderolabs/talosctl", "siderolabs/installer", "siderolabs/talos"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -10,7 +10,7 @@
     {
       description: "Talos - 3-day cooldown before raising upgrade PRs",
       matchDatasources: ["docker", "github-releases"],
-      matchPackageNames: ["ghcr.io/siderolabs/installer", "ghcr.io/siderolabs/talosctl", "/factory\\.talos\\.dev/"],
+      matchPackageNames: ["ghcr.io/siderolabs/installer", "ghcr.io/siderolabs/talosctl", "siderolabs/talos", "/factory\\.talos\\.dev/"],
       minimumReleaseAge: "3 days",
     },
     {

--- a/kubernetes/system-upgrade/talos-upgrade.yaml
+++ b/kubernetes/system-upgrade/talos-upgrade.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: system-upgrade
 spec:
   talos:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    # renovate: datasource=github-releases depName=siderolabs/talos
     version: v1.13.5
   policy:
     rebootMode: default

--- a/setup/talos/talconfig.yaml
+++ b/setup/talos/talconfig.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
-# renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+# renovate: datasource=github-releases depName=siderolabs/talos
 talosVersion: v1.13.5
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.2


### PR DESCRIPTION
## Summary
- Follow-up to #5897. `ghcr.io/siderolabs/installer` (docker/OCI datasource) has no `releaseTimestamp` Renovate can read, so the existing 3-day Talos cooldown (`.renovate/overrides.json5`) never actually measured age - it just tripped the new `timestamp-optional` warning every run.
- The upstream `siderolabs/talos` GitHub releases carry real `published_at` timestamps and use the exact same `vX.Y.Z` tags as the installer image (confirmed `v1.13.4`/`v1.13.5` both present as GitHub release tags).
- Re-pointed the two version annotations (`kubernetes/system-upgrade/talos-upgrade.yaml`, `setup/talos/talconfig.yaml`) from `datasource=docker depName=ghcr.io/siderolabs/installer` to `datasource=github-releases depName=siderolabs/talos`, and added `siderolabs/talos` to the existing Talos cooldown (`overrides.json5`) and Talos Group (`groups.json5`) package-name matches so grouping/commit-topic behavior and the cooldown itself keep applying to the new depName.
- Net effect: Talos updates get a real, warning-free 3-day soak again. victoria-logs charts and claude-code-action (GHCR OCI chart / Actions digest pins) don't have an equivalent upstream timestamp source, so they continue to rely on `timestamp-optional` from #5897.

## Test plan
- [x] `npx -p renovate renovate-config-validator` passes on `.github/renovate.json5`, `.renovate/overrides.json5`, `.renovate/groups.json5`
- [x] YAML syntax of both edited manifests confirmed valid
- [ ] After merge, confirm the next Renovate run resolves `siderolabs/talos` via github-releases without the "did not have a releaseTimestamp" warning, and that PR #5898 (or its successor) still reflects the correct Talos group commit topic

https://claude.ai/code/session_01NhVGgGmRWABDeTT92bRbew